### PR TITLE
Fix pkg Makefile not being honored on package rebuild

### DIFF
--- a/package-funcs.php
+++ b/package-funcs.php
@@ -327,6 +327,15 @@ class Packages
 			var_dump($cmd, $output, $res);
 			throw new \Exception("Could not checkout branch $rel");
 		}
+		if (file_exists('Makefile')) {
+			print "Running 'make install' in $srcdir for $rel\n";
+			$cmd = "make install 2> /dev/null";
+			exec($cmd, $output, $res);
+			if ($res !== 0) {
+				var_dump($cmd, $output, $res);
+				throw new \Exception("Make didn't work");
+			}
+		}
 		if (file_exists($outfile)) {
 			unlink($outfile);
 		}


### PR DESCRIPTION
The build-packages.php script would step on changes implemented by package specific Makefiles which are supported in other places when it detected the changes files and forcibly rebuilt the pkg. The Makefile would run in src/immutable-xyz then get steppd on in src/pkgbuild/xyz.

This change had the rebuild process re-running the 'make install' if the Makefile exists.

This was never relevant before because the only package using a Makefile was sounds_us which doesn't ever really change.